### PR TITLE
Removed 'GoogleNews' library from rqmnts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cachetools==5.3.3
 certifi==2024.2.2
 charset-normalizer==2.0.12
 click==8.1.7
-dateparser==1.2.0
+dateparser==0.7.6
 dnspython==1.16.0
 feedparser==6.0.11
 gitdb==4.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ feedparser==6.0.11
 gitdb==4.0.11
 GitPython==3.1.42
 gnews==0.3.6
-GoogleNews==1.6.14
 idna==3.6
 Jinja2==3.1.3
 joblib==1.3.2


### PR DESCRIPTION
removed this library since it is not used in the app.... it is also conflicting with pygooglenews